### PR TITLE
Remove new_seed RANGE variables

### DIFF
--- a/mechanisms/Isinunoisy.mod
+++ b/mechanisms/Isinunoisy.mod
@@ -75,7 +75,7 @@ INDEPENDENT {t FROM 0 TO 1 WITH 1 (ms)}
 
 NEURON {
     POINT_PROCESS Isinunoisy
-    RANGE amp, i, freq, m, s, tau, x, new_seed
+    RANGE amp, i, freq, m, s, tau, x
     ELECTRODE_CURRENT i
 }
 

--- a/mechanisms/Isinunoisy2.mod
+++ b/mechanisms/Isinunoisy2.mod
@@ -76,7 +76,7 @@ INDEPENDENT {t FROM 0 TO 1 WITH 1 (ms)}
 
 NEURON {
     POINT_PROCESS Isinunoisy2
-    RANGE amp, i, freq, m, s, tau, x, new_seed
+    RANGE amp, i, freq, m, s, tau, x
     ELECTRODE_CURRENT i
 }
 

--- a/readme.html
+++ b/readme.html
@@ -66,4 +66,9 @@ PSTH) In red, the best fit sinusoid. In blue the sinusoid is displayed
 which is subsequently modified by noise to produce the input.
 
 <img src="./screenshot3.jpg" alt="screenshot3">
+
+Changelog
+=========
+2023-02-28: Do not declare functions and variables with the same name. This is
+            required by https://github.com/neuronsimulator/nrn/pull/1992
 </pre></html>


### PR DESCRIPTION
Fixes error in NEURON newer than 8.2.2:
Error: new_seed used as both variable and function in file Isinunoisy2.mod.

Was not seen before because without the fixes in https://github.com/neuronsimulator/nrn-modeldb-ci/pull/77 the MOD file was not compiled.